### PR TITLE
chore(ci): auto-publish using github-actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+
+name: Publish
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: enriikke/gatsby-gh-pages-action@v2
+      with:
+        access-token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
## Types of changes

This PR sets up github-actions to auto-publish gatsby

## Description of changes

But you need to make the folllowing changes:

1. Setup master as the `github-pages` branch, instead of `gh-pages` in https://github.com/willmendesneto/willmendesneto.github.io/settings
2. Create a secret named `ACCESS-TOKEN` in https://github.com/willmendesneto/willmendesneto.github.io/secrets/actions containing h a github api-key with writting permissions.
